### PR TITLE
Fix linking warnings on OS X

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -122,7 +122,7 @@
         ],
         'GCC_ENABLE_CPP_RTTI': 'YES',
         'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-        'MACOSX_DEPLOYMENT_TARGET':'10.10',
+        'MACOSX_DEPLOYMENT_TARGET':'10.11',
         'CLANG_CXX_LIBRARY': 'libc++',
         'CLANG_CXX_LANGUAGE_STANDARD':'c++14',
         'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0'


### PR DESCRIPTION
The build currently works flawlessly on OS X but does spit out a lot of these warnings:

> ld: warning: object file (/Users/danespringmeyer/projects/vtshaver/mason_packages/.link/lib/libmbgl-core.a(geojson.cpp.o)) was built for newer OSX version (10.11) than being linked (10.10)

To make sure the build is as friendly as possible, this PR fixes the warning. The issues is that mason is building binaries that are intended to only be used on OS X >= 10.11. This matches that minimum OS X version to clearly and explicitly state that only OS X >= 10.11 is supported (which should be fine for all open source users).

/cc @GretaCB 