### PR TITLE
Fix expression evaluation by passing zoom levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtshaver",
-  "version": "0.1.0",
+  "version": "0.1.0-expr",
   "description": "Creates style-optimized vector tiles",
   "main": "./lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtshaver",
-  "version": "0.1.0-expr",
+  "version": "0.1.0",
   "description": "Creates style-optimized vector tiles",
   "main": "./lib/index.js",
   "repository": {


### PR DESCRIPTION
Expression evaluation was broken when `zoom` was involved. This (I think) fixes the issue.

It also:
 - moves to using `float` type for zoom, which is what mbgl uses.
 - removes `PropertyValueMapping` which was duplicative

TODO before merging:
  - [x] Add regression test
  - [x] Test further downstream (does this fix style rendering when expressions are used?)

I've been onboarding @zmofei onto learning more about vector tile shaving + this project: this would be a great task for @zmofei to finish and roll out into production globally (and in .cn).

/cc @mapsam @ian29 