### PR TITLE
fix readme demo bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ var fs = require('fs');
 
 var buffer = fs.readFileSync('/path/to/vector-tile.mvt');
 var style = require('/path/to/style.json');
-var filters = shaver.styleToFilters(style);
+var filters = new shaver.Filters(shaver.styleToFilters(style));
 
 var options = {
     filters: filters,  // required


### PR DESCRIPTION
The `options.filters` must be a shaver.Filters objects. The readme demo passes a JavaScript Object to `options.filters`, make it return the error below: 

```
/Users/mapbox-mofei/dev/mapbox/vtshaver/temp.js:26
      if (err) throw err;
               ^

Error: option 'filters' must be a shaver.Filters object
    at Object.<anonymous> (/Users/mapbox-mofei/dev/mapbox/vtshaver/temp.js:24:8)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```