### PR TITLE
Add to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,4 @@ API-CPP.md
 API-JavaScript.md
 .vscode
 *.*~
+.nyc_output


### PR DESCRIPTION
Add .nyc_output to npmignore to avoid packaging data in published package. This is a needed followup after coverage tracking for the JS files landed in #29