### PR TITLE
Layer names with only numbers fail to parse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ matrix:
         - make sanitize
       # Overrides `before_script` (tests are already run in `make sanitize`)
       before_script:
+        - true
     # osx sanitizer build node v6/debug
     - os: osx
       env: BUILDTYPE=debug TOOLSET=asan
@@ -113,6 +114,7 @@ matrix:
         - make sanitize
       # Overrides `before_script` (tests are already run in `make sanitize`)
       before_script:
+        - true
 
     ## ** Builds that do not get published **
 
@@ -132,6 +134,7 @@ matrix:
         - make ${BUILDTYPE}
       # Overrides `script` to disable publishing
       script:
+        - true
     # Coverage build
     - os: linux
       env: BUILDTYPE=debug CXXFLAGS="--coverage" LDFLAGS="--coverage"
@@ -157,8 +160,10 @@ matrix:
         - make format
       # Overrides `before_script`, no need to run tests
       before_script:
+        - true
       # Overrides `script` to disable publishing
       script:
+        - true
     # Clang tidy build
     - os: linux
       env: CLANG_TIDY
@@ -172,5 +177,7 @@ matrix:
         - make tidy
       # Overrides `before_script`, no need to run tests
       before_script:
+        - true
       # Overrides `script` to disable publishing
       script:
+        - true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 
-sudo: false
-
 # enable c++11/14 builds
 addons:
   apt:

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,7 +37,8 @@
         '-Wold-style-cast',
         '-Wno-error=unused-variable',
         '-Wno-error=unused-value',
-        '-DRAPIDJSON_HAS_STDSTRING=1'
+        '-DRAPIDJSON_HAS_STDSTRING=1',
+        '-Wno-deprecated-declarations'
       ]
   },
   'targets': [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/vtshaver",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -156,14 +156,14 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.3.0.tgz",
-      "integrity": "sha512-jEdKvDRPW95EBNRhpGuzZl6DpToDtQkJGlicz7QH8lWz+IxDfHUJV46yj+g8wgWGFiiTY3+xUrJKo6XrYjFRjw==",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.12.0.tgz",
+      "integrity": "sha512-tRSvlYUI73LOkvS1iQhVwnltoI/QC4ZaLOAS6NM6zx0NwJfsGUJDPucsaKif8l7Sce1ECLd8LYs1MRCyJjdo5Q==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.0",
         "csscolorparser": "~1.0.2",
-        "json-stringify-pretty-compact": "^1.2.0",
+        "json-stringify-pretty-compact": "^2.0.0",
         "minimist": "0.0.8",
         "rw": "^1.3.3",
         "sort-object": "^0.3.2"
@@ -171,7 +171,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -846,9 +846,9 @@
       "dev": true
     },
     "ignore-walk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
-      "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -1105,9 +1105,9 @@
       "dev": true
     },
     "json-stringify-pretty-compact": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-1.2.0.tgz",
-      "integrity": "sha512-/11Pj1OyX814QMKO7K8l85SHPTr/KsFxHp8GE2zVa0BtJgGimDjXHfM3FhC7keQdWDea7+nXf+f1de7ATZcZkQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -1264,9 +1264,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "needle": {
       "version": "2.2.2",
@@ -1291,9 +1291,9 @@
       "dev": true
     },
     "node-pre-gyp": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
-      "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+      "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -1304,13 +1304,13 @@
         "rc": "^1.2.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
-        "tar": "^4"
+        "tar": "^4.4.2"
       }
     },
     "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
       "requires": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -1346,17 +1346,26 @@
       }
     },
     "npm-bundled": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
-      "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "npm-packlist": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
-      "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
       "requires": {
         "ignore-walk": "^3.0.1",
-        "npm-bundled": "^1.0.1"
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "npmlog": {

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   "author": "Mapbox",
   "license": "ISC",
   "dependencies": {
-    "@mapbox/mapbox-gl-style-spec": "^13.3.0",
-    "nan": "^2.11.1",
-    "node-pre-gyp": "^0.12.0"
+    "@mapbox/mapbox-gl-style-spec": "^13.12.0",
+    "nan": "^2.14.0",
+    "node-pre-gyp": "^0.14.0"
   },
   "bin": {
     "vtshave": "./bin/vtshave.js",

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -211,12 +211,12 @@ NAN_METHOD(Filters::New) {
 }
 
 NAN_METHOD(Filters::layers) {
-  auto layers = Nan::New<v8::Array>();
-  std::uint32_t idx = 0;
-  Filters* filters = Nan::ObjectWrap::Unwrap<Filters>(info.Holder());
-  for (auto const& lay : filters->filters) {
-    Nan::Set(layers, idx, Nan::New<v8::String>(lay.first).ToLocalChecked());
-    idx++;
-  }
-  info.GetReturnValue().Set(layers);
+    auto layers = Nan::New<v8::Array>();
+    std::uint32_t idx = 0;
+    auto* filters = Nan::ObjectWrap::Unwrap<Filters>(info.Holder());
+    for (auto const& lay : filters->filters) {
+        Nan::Set(layers, idx, Nan::New<v8::String>(lay.first).ToLocalChecked());
+        idx++;
+    }
+    info.GetReturnValue().Set(layers);
 }

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -215,8 +215,7 @@ NAN_METHOD(Filters::layers) {
     std::uint32_t idx = 0;
     auto* filters = Nan::ObjectWrap::Unwrap<Filters>(info.Holder());
     for (auto const& lay : filters->filters) {
-        Nan::Set(layers, idx, Nan::New<v8::String>(lay.first).ToLocalChecked());
-        idx++;
+        Nan::Set(layers, idx++, Nan::New<v8::String>(lay.first).ToLocalChecked());
     }
     info.GetReturnValue().Set(layers);
 }

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -24,6 +24,7 @@ void Filters::Initialize(v8::Local<v8::Object> target) {
     v8::Local<v8::FunctionTemplate> lcons = Nan::New<v8::FunctionTemplate>(Filters::New);
     lcons->InstanceTemplate()->SetInternalFieldCount(1);
     lcons->SetClassName(Nan::New("Filters").ToLocalChecked());
+    Nan::SetPrototypeMethod(lcons, "layers", layers);
     target->Set(Nan::New("Filters").ToLocalChecked(), lcons->GetFunction());
     constructor().Reset(lcons);
 }
@@ -81,7 +82,7 @@ NAN_METHOD(Filters::New) {
                     v8::Local<v8::Value> layer_name_val = layers->Get(i);
                     // LCOV_EXCL_START
                     // the layer_name_val is the name of the object, since we have checked the layers->Length(), which means layers->Get(i) can not be null undefined or others
-                    if (!layer_name_val->IsString() || layer_name_val->IsNull() || layer_name_val->IsUndefined()) {
+                    if (layer_name_val->IsNull() || layer_name_val->IsUndefined()) {
                         Nan::ThrowError("layer name must be a string and cannot be null or undefined");
                         return;
                     }
@@ -210,4 +211,15 @@ NAN_METHOD(Filters::New) {
 
         info.GetReturnValue().Set(info.This());
     }
+}
+
+NAN_METHOD(Filters::layers) {
+  auto layers = Nan::New<v8::Array>();
+  std::size_t idx = 0;
+  Filters* filters = Nan::ObjectWrap::Unwrap<Filters>(info.Holder());
+  for (auto const& lay : filters->filters) {
+    Nan::Set(layers, idx, Nan::New<v8::String>(lay.first).ToLocalChecked());
+    idx++;
+  }
+  info.GetReturnValue().Set(layers);
 }

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -79,18 +79,15 @@ NAN_METHOD(Filters::New) {
                 std::uint32_t length = layers->Length();
                 for (std::uint32_t i = 0; i < length; ++i) {
                     // get v8::String containing layer name
-                    v8::Local<v8::Value> layer_name_val = layers->Get(i);
-                    // LCOV_EXCL_START
-                    // the layer_name_val is the name of the object, since we have checked the layers->Length(), which means layers->Get(i) can not be null undefined or others
-                    if (layer_name_val->IsNull() || layer_name_val->IsUndefined()) {
+                    v8::Local<v8::Value> layer_key = layers->Get(i);
+                    // the layer_key is the name of the object, since we have checked the layers->Length(), which means layers->Get(i) can not be null undefined or others
+                    if (layer_key->IsNull() || layer_key->IsUndefined()) {
                         Nan::ThrowError("layer name must be a string and cannot be null or undefined");
                         return;
                     }
-                    // LCOV_EXCL_STOP
-                    auto layer_name = layer_name_val.As<v8::String>();
 
                     // get v8::Object containing layer
-                    v8::Local<v8::Value> layer_val = filters->Get(layer_name);
+                    v8::Local<v8::Value> layer_val = filters->Get(layer_key);
 
                     if (!layer_val->IsObject() || layer_val->IsNull() || layer_val->IsUndefined()) {
                         Nan::ThrowError("layer must be an object and cannot be null or undefined");
@@ -197,7 +194,7 @@ NAN_METHOD(Filters::New) {
                         return;
                     }
 
-                    std::string source_layer = *v8::String::Utf8Value(layer_name->ToString());
+                    std::string source_layer = *v8::String::Utf8Value(layer_key);
 
                     self->add_filter(std::move(source_layer), std::move(filter), std::move(property), minzoom, maxzoom);
                 }
@@ -215,7 +212,7 @@ NAN_METHOD(Filters::New) {
 
 NAN_METHOD(Filters::layers) {
   auto layers = Nan::New<v8::Array>();
-  std::size_t idx = 0;
+  std::uint32_t idx = 0;
   Filters* filters = Nan::ObjectWrap::Unwrap<Filters>(info.Holder());
   for (auto const& lay : filters->filters) {
     Nan::Set(layers, idx, Nan::New<v8::String>(lay.first).ToLocalChecked());

--- a/src/filters.hpp
+++ b/src/filters.hpp
@@ -23,6 +23,7 @@ class Filters : public Nan::ObjectWrap {
 
     // method required for the constructor
     static NAN_METHOD(New); // Filters instance is stored here
+    static NAN_METHOD(layers);
 
     static Nan::Persistent<v8::FunctionTemplate>& constructor();
 

--- a/test/vtshaver.test.js
+++ b/test/vtshaver.test.js
@@ -34,6 +34,20 @@ var style_one_feature = require('./fixtures/styles/one-feature.json');
 var style_expressions_legacy = require('./fixtures/styles/expressions-legacy.json');
 var style_expressions = require('./fixtures/styles/expressions.json');
 
+test.only('layer names as numbers', function(t) {
+  const filters = Shaver.styleToFilters({
+    layers: [
+      {
+         "source-layer" : "1"
+      }
+    ]
+  });
+  t.deepEquals(filters,{ '1': { filters: true, minzoom: 0, maxzoom: 22, properties: [] } })
+  var filter_obj = new Shaver.Filters(filters);
+  t.ok(filter_obj);
+  t.end();
+})
+
 // making sure we don't change our fixtures accidentally
 test('buffer pre-test', function(t) {
   t.equals(defaultBuffer.length, 7718, 'expected pbf size before filtering');

--- a/test/vtshaver.test.js
+++ b/test/vtshaver.test.js
@@ -34,7 +34,7 @@ var style_one_feature = require('./fixtures/styles/one-feature.json');
 var style_expressions_legacy = require('./fixtures/styles/expressions-legacy.json');
 var style_expressions = require('./fixtures/styles/expressions.json');
 
-test.only('layer names as numbers', function(t) {
+test('layer names as numbers', function(t) {
   const filters = Shaver.styleToFilters({
     layers: [
       {
@@ -45,6 +45,7 @@ test.only('layer names as numbers', function(t) {
   t.deepEquals(filters,{ '1': { filters: true, minzoom: 0, maxzoom: 22, properties: [] } })
   var filter_obj = new Shaver.Filters(filters);
   t.ok(filter_obj);
+  t.deepEqual(filter_obj.layers(),['1']);
   t.end();
 })
 


### PR DESCRIPTION
If a source-layer has a name like `"1234"` it should be considered a valid string. But currently we throw since the value is  incorrectly detected as a number.