### PR TITLE
test asserting visibility:none results in no shaving

### DIFF
--- a/test/fixtures/styles/visibility-none.json
+++ b/test/fixtures/styles/visibility-none.json
@@ -1,0 +1,23 @@
+{
+	"version": 1,
+	"name": "hello invisible world",
+	"center": [
+	    -122.51238479904751,
+	    37.77981694417855
+	],
+	"zoom": 16.5252340340155,
+	"bearing": 0,
+	"pitch": 0,
+	"layers": [
+		{
+			"type": "symbol",
+			"source": "composite",
+			"id": "helloooo",
+			"source-layer": "hello",
+      "layout": {
+        "visibility": "none"
+      }
+		}
+	],
+	"owner": "greta"
+}

--- a/test/vtshaver.test.js
+++ b/test/vtshaver.test.js
@@ -434,6 +434,23 @@ test('success: layers sucessfully shaved, features shaved - equal ==', function(
   });
 });
 
+test('success: layer remains with visibility: none set in style layer', function(t) {
+  var filters = new Shaver.Filters(Shaver.styleToFilters(require('./fixtures/styles/visibility-none.json')));
+  var buffer = mvtf.get('017').buffer; // single layer called "hello" with one point feature
+
+  Shaver.shave(buffer, {filters: filters, zoom: 16}, function(err, shavedTile) {
+    if (err) throw err;
+    var postTile = vtinfo(shavedTile);
+    t.ok(shavedTile);
+    t.equals(postTile.layers.length, 1, 'shaved tile contains expected number of layers');
+    t.equals(postTile.layers[0].features, 1, 'expected number of features after filtering');
+    t.equals(postTile.layers[0].name, 'hello', 'shaved tile contains expected layer');
+    t.ok((shavedTile.length < buffer.length && shavedTile.length !== 0), 'successfully shaved');
+    if (SHOW_COMPARE) console.log("**** Tile size before: " + buffer.length + "\n**** Tile size after: " + shavedTile.length);
+    t.end();
+  });
+});
+
 test('success: evaluate function returns empty object because no matches', function(t) {
   var sizeBefore = defaultBuffer.length;
   var beforeTile = vtinfo(defaultBuffer);


### PR DESCRIPTION
This adds a new test to assert that setting a style layer with `"visibility": "none"` doesn't result in the layer being dropped from the style. 

cc @ClareTrainor 